### PR TITLE
Update the `.script-item` to show a full description of each script

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -51,7 +51,6 @@
     color: #fff;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     height: 100%;
     min-height: 200px;
     overflow: hidden;
@@ -75,10 +74,7 @@
     font-size: 13px;
     color: #ccc;
     overflow: hidden;
-    text-overflow: ellipsis;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
 }
 
 .script-footer {
@@ -87,6 +83,7 @@
     align-items: center;
     padding-top: 10px;
     border-top: 1px solid #444;
+    margin-top: auto;
 }
 
 .script-footer .pricing {


### PR DESCRIPTION
- Removed the `text-overflow: ellipsis;` and `-webkit-line-clamp: 2;` to allow each script so show the full description 
- Added `margin-top: auto;` to the `script-footer` to push the footer to the bottom, a side effect of removing `justify-content: space-between;` from the parent